### PR TITLE
Fix for crashing with duplicate email in signup - #22

### DIFF
--- a/src/auth/handlers.rs
+++ b/src/auth/handlers.rs
@@ -73,30 +73,40 @@ pub fn signup_post(conn: ObservDbConn, mut cookies: Cookies, form: Form<SignUpFo
 
     use crate::schema::users::dsl::*;
 
-    insert_into(users)
-        .values(&newuser)
-        .execute(&*conn)
-        .expect("Failed to add user to database");
-
-    let user: User = users
-        .filter(&email.eq(newuser.email))
-        .first(&*conn)
-        .expect("Failed to get user from database");
-
+    // Check if user's email is already signed up
+    if let Some(user) = users
+        .filter(&email.eq(&*newuser.email))
+        .first::<User>(&*conn)
+        .optional()
+        .expect("Failed to get user from database")
     {
-        use crate::schema::relation_group_user::dsl::*;
-        insert_into(relation_group_user)
-            .values(&NewRelationGroupUser {
-                group_id: 0,
-                user_id: user.id,
-            })
+        return Redirect::to(format!("/signup?e={}", FormError::UserExists));
+    } else {
+        // Insert the new user into the database
+        insert_into(users)
+            .values(&newuser)
             .execute(&*conn)
-            .expect("Failed to insert new relation into database");
+            .expect("Failed to add user to database");
+        
+        let user: User = users
+            .filter(&email.eq(&*newuser.email))
+            .first(&*conn)
+            .expect("Failed to get user from database");
+        {
+            use crate::schema::relation_group_user::dsl::*;
+            insert_into(relation_group_user)
+                .values(&NewRelationGroupUser {
+                    group_id: 0,
+                    user_id: user.id,
+                })
+                .execute(&*conn)
+                .expect("Failed to insert new relation into database");
+        }
+
+        cookies.add_private(Cookie::new("user_id", format!("{}", user.id)));
+
+        Redirect::to(format!("/users/{}", user.id))
     }
-
-    cookies.add_private(Cookie::new("user_id", format!("{}", user.id)));
-
-    Redirect::to(format!("/users/{}", user.id))
 }
 
 /// GET handler for `/login`

--- a/src/auth/handlers.rs
+++ b/src/auth/handlers.rs
@@ -74,11 +74,12 @@ pub fn signup_post(conn: ObservDbConn, mut cookies: Cookies, form: Form<SignUpFo
     use crate::schema::users::dsl::*;
 
     // Check if user's email is already signed up
-    if let Some(user) = users
+    if users
         .filter(&email.eq(&*newuser.email))
         .first::<User>(&*conn)
         .optional()
         .expect("Failed to get user from database")
+        .is_some()
     {
         return Redirect::to(format!("/signup?e={}", FormError::UserExists));
     } else {

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -103,6 +103,8 @@ pub enum FormError {
     Credentials,
     /// The password and it's repeat are not the same
     PasswordMismatch,
+    /// The email is already in use by another user
+    UserExists,
     /// A date field was the wrong format invalid
     InvalidDate,
     /// Some other unknown error
@@ -122,6 +124,7 @@ impl fmt::Display for FormError {
                 FormError::Password => "password",
                 FormError::Credentials => "credentials",
                 FormError::PasswordMismatch => "mismatch",
+                FormError::UserExists => "exists",
                 FormError::InvalidDate => "date",
                 FormError::Other => "other",
             }
@@ -137,6 +140,7 @@ impl<T: AsRef<str>> From<T> for FormError {
             "password" => FormError::Password,
             "credentials" => FormError::Credentials,
             "mismatch" => FormError::PasswordMismatch,
+            "exists" => FormError::UserExists,
             "date" => FormError::InvalidDate,
             "other" => FormError::Other,
             _ => FormError::Other,

--- a/templates/form-error.html
+++ b/templates/form-error.html
@@ -19,6 +19,10 @@ This file can be included into another page to display an error in a form.
 <div class="alert alert-warning">
     Incorrect email or password. Make sure that they are spelled correctly.
 </div>
+{% when FormError::UserExists %}
+<div class="alert alert-warning">
+    Email is already in use, please login or try another email.
+</div>
 {% when FormError::PasswordMismatch %}
 <div class="alert alert-warning">
     Passwords do not match, please re-type them and try again.


### PR DESCRIPTION
**Related Issues**
Related to issue #22

**Describe the Changes**
Added a check to see whether a user's email is already in the database, if so then the user is redirected back to the sign up page, prompting them to use another email.

**Still To Do**
The fundamental problem should be solved, just the way it is coded could potentially be better.

**Problems**
Not sure if generating the same query twice in a row is the best way to go about checking for existing users, I'll have to look into how returning values work in this environment.

**Acknowledgements**
@rushsteve1 for referencing #5, which provided a good example that helped to tackle this issue.
