### PR TITLE
Fix for adding same user to group

### DIFF
--- a/src/auth/handlers.rs
+++ b/src/auth/handlers.rs
@@ -88,7 +88,7 @@ pub fn signup_post(conn: ObservDbConn, mut cookies: Cookies, form: Form<SignUpFo
             .values(&newuser)
             .execute(&*conn)
             .expect("Failed to add user to database");
-        
+
         let user: User = users
             .filter(&email.eq(&*newuser.email))
             .first(&*conn)

--- a/src/projects/handlers.rs
+++ b/src/projects/handlers.rs
@@ -212,16 +212,15 @@ pub fn project_member_add(
     let pu = project_users(&*conn, &p);
 
     use crate::schema::users::dsl::*;
-    let all_users: Vec<User> = users
-        .load(&*conn)
-        .expect("Failed to get users from database");
 
     if l.0.tier > 0 || l.0.id == p.owner_id {
         Ok(AddUserTemplate {
             logged_in: Some(l.0),
             project: p,
             all_users: {
-                all_users
+                users
+                    .load(&*conn)
+                    .expect("Failed to get users from database")
                     .iter()
                     .filter(|&e| !pu.iter().any(|x| e == x))
                     .cloned()

--- a/src/projects/handlers.rs
+++ b/src/projects/handlers.rs
@@ -209,15 +209,23 @@ pub fn project_member_add(
             .expect("Failed to get project from database")
     };
 
+    let pu = project_users(&*conn, &p);
+
+    use crate::schema::users::dsl::*;
+    let all_users: Vec<User> = users
+        .load(&*conn)
+        .expect("Failed to get users from database");
+
     if l.0.tier > 0 || l.0.id == p.owner_id {
         Ok(AddUserTemplate {
             logged_in: Some(l.0),
             project: p,
             all_users: {
-                use crate::schema::users::dsl::*;
-                users
-                    .load(&*conn)
-                    .expect("Failed to get users from database")
+                all_users
+                    .iter()
+                    .filter(|&e| !pu.iter().any(|x| e == x))
+                    .cloned()
+                    .collect()
             },
         })
     } else {


### PR DESCRIPTION
**Related Issues**
Related to #24 

**Describe the Changes**
Added a filter that checks to see which users are already in the project, and removes them from selection.

**Still To Do**
This issue leads into #25, now that this issue is potentially fixed.

**Problems**
Now that the user selection list can be empty, fixing this issue leads to #25 occurring when those requirements are met, so fixing #25 will completely solve the overall problem.

**Acknowledgements**
@rushsteve1 for mentioning the functions `.filter()` and `.any()`, led to a simple solution that already exists in `groups/handlers.rs`
