### PR TITLE
Guard Meeting Codes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ Cargo.lock
 .vscode
 *.swp
 .directory
+observatory-new.code-workspace
+.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,3 @@ Cargo.lock
 *.swp
 .directory
 observatory-new.code-workspace
-.gitignore

--- a/templates/group/group.html
+++ b/templates/group/group.html
@@ -62,7 +62,7 @@ Room: {{ val }}
     {% when Some with (u) %}
     <li>
         Meeting at {{ meeting.happened_at }}
-        {% if u.tier > 1 %}
+        {% if u.tier > 0 %}
             code:
             <code>{{ meeting.code }}</code>
             <a href="/big?text={{ meeting.code }}">View</a>

--- a/templates/group/group.html
+++ b/templates/group/group.html
@@ -58,11 +58,18 @@ Room: {{ val }}
 <h2>Meetings</h2>
 <ul>
     {% for meeting in meetings %}
+    {% match logged_in %}
+    {% when Some with (u) %}
     <li>
-        Meeting at {{ meeting.happened_at }} code:
-        <code>{{ meeting.code }}</code>
-        <a href="/big?text={{ meeting.code }}">View</a>
+        Meeting at {{ meeting.happened_at }}
+        {% if u.tier > 1 %}
+            code:
+            <code>{{ meeting.code }}</code>
+            <a href="/big?text={{ meeting.code }}">View</a>
+        {% endif %}
     </li>
+    {% when None %}
+    {% endmatch %}
     {% endfor %}
 </ul>
 


### PR DESCRIPTION
**Related Issues**
Fixes #32 

**Describe the Changes**
Added a guard under `templates/group/group.html` so that only users of tier 1 or higher can view the codes.