### PR TITLE
Check for duplicate attendance codes

### DIFF
--- a/src/attend/handlers.rs
+++ b/src/attend/handlers.rs
@@ -58,12 +58,21 @@ pub fn attend_post(conn: ObservDbConn, l: UserGuard, code: Form<AttendCode>) -> 
         };
 
         use crate::schema::attendances::dsl::*;
-        let user_attended = attendances
-            .filter(meeting_id.eq(mid).and(user_id.eq(l.0.id)))
-            .first::<Attendance>(&*conn)
-            .optional()
-            .expect("Failed to get attendances from database")
-            .is_some();
+        let user_attended = if m.is_event() {
+            attendances
+                .filter(event_id.eq(eid).and(user_id.eq(l.0.id)))
+                .first::<Attendance>(&*conn)
+                .optional()
+                .expect("Failed to get attendances from database")
+                .is_some()
+        } else {
+            attendances
+                .filter(meeting_id.eq(mid).and(user_id.eq(l.0.id)))
+                .first::<Attendance>(&*conn)
+                .optional()
+                .expect("Failed to get attendances from database")
+                .is_some()
+        };
 
         if !user_attended && (m.is_event() || (!m.is_event() && user_in_group)) {
             let newattend = NewAttendance {

--- a/src/attend/templates.rs
+++ b/src/attend/templates.rs
@@ -12,5 +12,5 @@ use crate::templates::{filters, FormError, OptUser};
 #[template(path = "attend.html")]
 pub struct AttendTemplate {
     pub logged_in: OptUser,
-    pub error: Option<FormError>
+    pub error: Option<FormError>,
 }

--- a/templates/form-error.html
+++ b/templates/form-error.html
@@ -29,7 +29,7 @@ This file can be included into another page to display an error in a form.
 </div>
 {% when FormError::InvalidCode %}
 <div class="alert alert-warning">
-    The attendance code either does not exist, or is used for a group you are not a part of.
+    The attendance code is either invalid, or used for a group you are not a part of.
 </div>
 {% when FormError::InvalidDate %}
 <div class="alert alert-warning">


### PR DESCRIPTION
**Related Issues**
Related to issue #34 

**Describe the Changes**
Similar to #44, a check was made using a query to see if the user has already attended this meeting/event. This should check for duplicate attendance codes being submitted.

**Still To Do**
Have to check if user has attended an event already, as well.

**Problems**
Same as "Still To Do"

**Acknowledgements**
#44, for having an identical solution.
