### PR TITLE
Added github collision checking

### DIFF
--- a/src/templates.rs
+++ b/src/templates.rs
@@ -104,7 +104,9 @@ pub enum FormError {
     /// The password and it's repeat are not the same
     PasswordMismatch,
     /// The email is already in use by another user
-    UserExists,
+    EmailExists,
+    /// The github handel is already in use by another user
+    GitExists,
     /// An attendance code does not exist or is used by a non-affiliated member
     InvalidCode,
     /// A date field was the wrong format invalid
@@ -126,7 +128,8 @@ impl fmt::Display for FormError {
                 FormError::Password => "password",
                 FormError::Credentials => "credentials",
                 FormError::PasswordMismatch => "mismatch",
-                FormError::UserExists => "exists",
+                FormError::EmailExists => "emailExists",
+                FormError::GitExists => "gitExists",
                 FormError::InvalidCode => "code",
                 FormError::InvalidDate => "date",
                 FormError::Other => "other",
@@ -143,7 +146,8 @@ impl<T: AsRef<str>> From<T> for FormError {
             "password" => FormError::Password,
             "credentials" => FormError::Credentials,
             "mismatch" => FormError::PasswordMismatch,
-            "exists" => FormError::UserExists,
+            "emailExists" => FormError::EmailExists,
+            "gitExists" => FormError::GitExists,
             "code" => FormError::InvalidCode,
             "date" => FormError::InvalidDate,
             "other" => FormError::Other,

--- a/templates/form-error.html
+++ b/templates/form-error.html
@@ -19,9 +19,13 @@ This file can be included into another page to display an error in a form.
 <div class="alert alert-warning">
     Incorrect email or password. Make sure that they are spelled correctly.
 </div>
-{% when FormError::UserExists %}
+{% when FormError::EmailExists %}
 <div class="alert alert-warning">
     Email is already in use, please login or try another email.
+</div>
+{% when FormError::GitExists %}
+<div class="alert alert-warning">
+    GitHub Handle is already in use, please login or try another GitHub Handle.
 </div>
 {% when FormError::PasswordMismatch %}
 <div class="alert alert-warning">


### PR DESCRIPTION
Filter for seeing if a github handle is already in the database.

**Related Issues**
#27 

**Describe the Changes**
I added a filter to check to see if the github handles are already in the database. I also made changes to #23 pushed by @BrianMejia: 
- `UserExists` to `EmailExists` due to the vagueness of the variable name.
- Removed an else that was not needed due to the if calling a return

**Still To Do**
Nothing

**Problems**
None

**Acknowledgements**
@BrianMejia for letting me reuse _some_ of his code

