### PR TITLE
Test Concurrency Fixes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -58,14 +58,14 @@ mod users;
 #[database("sqlite_observ")]
 pub struct ObservDbConn(diesel::SqliteConnection);
 
-pub fn rocket(is_test : bool, test_config : Option<rocket::Config>) -> rocket::Rocket {
+pub fn rocket(test_config : Option<rocket::Config>) -> rocket::Rocket {
     // Load all the handlers
     use handlers::*;
 
     // Load the fairings
     use fairings::{AdminCheck, ConfigWrite, DatabaseCreate};
 
-    let app = if is_test {
+    let app = if test_config.is_some() {
         rocket::custom(test_config.unwrap())
     } else {
         rocket::ignite()
@@ -169,7 +169,7 @@ pub fn rocket(is_test : bool, test_config : Option<rocket::Config>) -> rocket::R
 /// then launches the server.
 fn main() {
     // Liftoff! Starts the webserver
-    rocket(false, None).launch();
+    rocket(None).launch();
 }
 
 /// Top-level module containing all the models.

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,17 +58,22 @@ mod users;
 #[database("sqlite_observ")]
 pub struct ObservDbConn(diesel::SqliteConnection);
 
-pub fn rocket() -> rocket::Rocket {
+pub fn rocket(is_test : bool, test_config : Option<rocket::Config>) -> rocket::Rocket {
     // Load all the handlers
     use handlers::*;
 
     // Load the fairings
     use fairings::{AdminCheck, ConfigWrite, DatabaseCreate};
 
+    let app = if is_test {
+        rocket::custom(test_config.unwrap())
+    } else {
+        rocket::ignite()
+    };
+    
     // Prepare webserver
-    rocket::ignite()
+    app.attach(ConfigWrite)
         // Attach fairings
-        .attach(ConfigWrite)
         .attach(DatabaseCreate)
         .attach(AdminCheck)
         .attach(ObservDbConn::fairing())
@@ -164,7 +169,7 @@ pub fn rocket() -> rocket::Rocket {
 /// then launches the server.
 fn main() {
     // Liftoff! Starts the webserver
-    rocket().launch();
+    rocket(false, None).launch();
 }
 
 /// Top-level module containing all the models.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -7,6 +7,8 @@ use rocket::http::Status;
 use rocket::local::Client;
 use std::fs;
 use std::path::Path;
+use std::collections::HashMap;
+use rocket::config::{Config, Environment, Value, LoggingLevel};
 
 #[derive(RustEmbed)]
 #[folder = "static/"]
@@ -24,39 +26,10 @@ pub use crate::users::handlers::*;
 // Embed the Migrations into the binary
 embed_migrations!("migrations/sqlite");
 
-#[test]
-fn launch() {
-    let _client = Client::new(rocket()).unwrap();
-    let response = _client.get("/").dispatch();
-    assert_eq!(response.status(), Status::Ok);
-}
+// Static connection variable
 
-#[test]
-fn check_static_content() {
-    let _client = Client::new(rocket()).unwrap();
-    let mut response = _client.get("/").dispatch();
-    assert!(response.body().is_some());
-    let body_str = response.body_string().unwrap();
-    assert!(body_str.contains("chat.rcos.io"));
-    Embed::get("img/favicon.webp").unwrap();
-}
-
-#[test]
-fn add_user() {
-    let mut db_exists = false;
-    if Path::new("./observ.sqlite").is_file() {
-        fs::rename("./observ.sqlite", "./observ.sqlite.backup")
-            .ok()
-            .expect("File Renaming Error");
-        db_exists = true;
-    }
-
-    fs::File::create("./observ.sqlite")
-        .ok()
-        .expect("File Creation Error");
-
-    let _client = Client::new(rocket()).unwrap();
-    let conn_url = _client
+fn create_connection_url(client : &rocket::local::Client) -> String {
+    return String::from(client
         .rocket()
         .config()
         .get_table("databases")
@@ -66,9 +39,117 @@ fn add_user() {
         .get("url")
         .unwrap()
         .as_str()
+        .unwrap());
+}
+
+fn setup(test_name : String) -> Option<rocket::Config> {
+    let mut db_path = String::from("./");
+    db_path.push_str(test_name.as_str());
+    db_path.push_str("/");
+
+    let db_path_exists = Path::new(db_path.as_str()).is_dir();
+
+    if !db_path_exists {
+        fs::create_dir(db_path.as_str())
+            .ok()
+            .expect("Dir Creation Error");
+    }
+
+
+    let mut db_file_path = String::from(db_path.as_str());
+    db_file_path.push_str(test_name.as_str());
+    db_file_path.push_str(".sqlite");
+
+    let db_file_exists = Path::new(db_file_path.as_str()).is_file();
+    
+    if !db_file_exists {
+        fs::File::create(db_file_path.as_str())
+            .ok()
+            .expect("File Creation Error");
+    }
+
+    let mut database_config = HashMap::new();
+    let mut databases = HashMap::new();
+    database_config.insert("url", Value::from(db_file_path.as_str()));
+    databases.insert("sqlite_observ", Value::from(database_config));
+
+    let config = Config::build(Environment::Development)
+        .root("/")
+        .address("localhost")
+        .port(8000)
+        .log_level(LoggingLevel::Normal)
+        .extra("databases", databases)
+        .finalize()
         .unwrap();
 
-    let conn = SqliteConnection::establish(conn_url)
+    Some(config)
+}
+
+fn cleanup(test_name : String) {
+    let mut db_path_string = String::from("./");
+    db_path_string.push_str(test_name.as_str());
+    db_path_string.push_str("/");
+
+    let mut db_file_string = String::from(db_path_string.as_str());
+    db_file_string.push_str(test_name.as_str());
+    db_file_string.push_str(".sqlite");
+
+    fs::remove_file(db_file_string)
+        .ok()
+        .expect("File Deletion Error");
+    
+    fs::remove_dir(db_path_string)
+        .ok()
+        .expect("Dir Deletion Error");
+}
+
+#[test]
+fn launch() {
+    let config = setup(String::from("test_launch"));
+
+    let _client = Client::new(rocket(true, config)).unwrap();
+    let conn_url = create_connection_url(&_client);
+
+    let conn = SqliteConnection::establish(conn_url.as_str())
+        .expect("Failed to connect to database in LaunchTest");
+    embedded_migrations::run(&conn).expect("Failed to run embedded migrations");
+
+    let response = _client.get("/").dispatch();
+    assert_eq!(response.status(), Status::Ok);
+
+    cleanup(String::from("test_launch"));
+}
+
+#[test]
+fn check_static_content() {
+    let config = setup(String::from("test_static_content"));
+
+    let _client = Client::new(rocket(true, config)).unwrap();
+    let conn_url = create_connection_url(&_client);
+
+    let conn = SqliteConnection::establish(conn_url.as_str())
+        .expect("Failed to connect to database in StaticContentTest");
+    embedded_migrations::run(&conn).expect("Failed to run embedded migrations");
+
+    let mut response = _client.get("/").dispatch();
+    assert!(response.body().is_some());
+
+    let body_str = response.body_string().unwrap();
+    assert!(body_str.contains("chat.rcos.io"));
+
+    Embed::get("img/favicon.webp").unwrap();
+
+    cleanup(String::from("test_static_content"));
+}
+
+#[test]
+fn add_user() {
+    let config = setup(String::from("test_add_user"));
+
+    let _client = Client::new(rocket(true, config)).unwrap();
+    let conn_url = create_connection_url(&_client);
+
+    let conn = SqliteConnection::establish(conn_url.as_str())
         .expect("Failed to connect to database in AddUserTest");
     embedded_migrations::run(&conn).expect("Failed to run embedded migrations");
 
@@ -110,13 +191,6 @@ fn add_user() {
     }
 
     assert_eq!("JD1".to_string(), user.handle);
-    fs::remove_file("./observ.sqlite")
-        .ok()
-        .expect("File Deletion Error");
-    
-    if db_exists {
-        fs::rename("./observ.sqlite.backup", "./observ.sqlite")
-            .ok()
-            .expect("File Renaming Error");
-    }
+
+    cleanup(String::from("test_add_user"));
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -107,7 +107,7 @@ fn cleanup(test_name : String) {
 fn launch() {
     let config = setup(String::from("test_launch"));
 
-    let _client = Client::new(rocket(true, config)).unwrap();
+    let _client = Client::new(rocket(config)).unwrap();
     let conn_url = create_connection_url(&_client);
 
     let conn = SqliteConnection::establish(conn_url.as_str())
@@ -124,7 +124,7 @@ fn launch() {
 fn check_static_content() {
     let config = setup(String::from("test_static_content"));
 
-    let _client = Client::new(rocket(true, config)).unwrap();
+    let _client = Client::new(rocket(config)).unwrap();
     let conn_url = create_connection_url(&_client);
 
     let conn = SqliteConnection::establish(conn_url.as_str())
@@ -146,7 +146,7 @@ fn check_static_content() {
 fn add_user() {
     let config = setup(String::from("test_add_user"));
 
-    let _client = Client::new(rocket(true, config)).unwrap();
+    let _client = Client::new(rocket(config)).unwrap();
     let conn_url = create_connection_url(&_client);
 
     let conn = SqliteConnection::establish(conn_url.as_str())


### PR DESCRIPTION
**Related Issues**
This is in relation to the test suite not working due to concurrency issues with SQLite.

**Describe the Changes**
Each test is sandboxed essentially, a folder and database file is created for each test that way the queries made by each test do not interrupt each other.

**Still To Do**
Is this structure (path/file for each test) suitable? I chose this method since even sharing a directory between tests is a bit more complex. Also, in case we need extra files for a test (some static content, for example) these could just be placed in their respective directory.

**Problems**
Before the two commits there was a problem where the `Rocket.toml` file would get generated even though one exists already. It has not happened since I set a root directory that the ConfigBuilder searches for, but if this comes up again this could open another issue.

**Acknowledgements**
@rushsteve1 for the suggestions on how to deal with test concurrency.
