### PR TITLE
Added Former/External Member and External Project flags.

### DIFF
--- a/migrations/sqlite/2019-09-24-203727_alter_users_external/down.sql
+++ b/migrations/sqlite/2019-09-24-203727_alter_users_external/down.sql
@@ -1,0 +1,1 @@
+-- This file should undo anything in `up.sql`

--- a/migrations/sqlite/2019-09-24-203727_alter_users_external/up.sql
+++ b/migrations/sqlite/2019-09-24-203727_alter_users_external/up.sql
@@ -1,0 +1,4 @@
+-- Add former member flag
+ALTER TABLE users ADD former boolean NOT NULL DEFAULT false;
+-- Add external member flag
+ALTER TABLE users ADD extrn boolean NOT NULL DEFAULT false;

--- a/migrations/sqlite/2019-09-24-203727_alter_users_external/up.sql
+++ b/migrations/sqlite/2019-09-24-203727_alter_users_external/up.sql
@@ -1,4 +1,4 @@
 -- Add former member flag
-ALTER TABLE users ADD former boolean NOT NULL DEFAULT false;
+ALTER TABLE users ADD former boolean NOT NULL DEFAULT 0;
 -- Add external member flag
-ALTER TABLE users ADD extrn boolean NOT NULL DEFAULT false;
+ALTER TABLE users ADD extrn boolean NOT NULL DEFAULT 0;

--- a/migrations/sqlite/2019-10-15-154635_alter_projects_external/down.sql
+++ b/migrations/sqlite/2019-10-15-154635_alter_projects_external/down.sql
@@ -1,0 +1,1 @@
+-- This file should undo anything in `up.sql`

--- a/migrations/sqlite/2019-10-15-154635_alter_projects_external/up.sql
+++ b/migrations/sqlite/2019-10-15-154635_alter_projects_external/up.sql
@@ -1,0 +1,2 @@
+-- Add external member flag
+ALTER TABLE projects ADD extrn boolean NOT NULL DEFAULT 0;

--- a/src/auth/handlers.rs
+++ b/src/auth/handlers.rs
@@ -53,6 +53,9 @@ impl From<SignUpForm> for NewUser {
         newuser.tier = 0;
         newuser.active = true;
 
+        newuser.former = false;
+        newuser.extrn = false;
+
         return newuser;
     }
 }

--- a/src/fairings.rs
+++ b/src/fairings.rs
@@ -111,6 +111,8 @@ impl Fairing for AdminCheck {
                 tier: admin.tier,
                 active: admin.active,
                 mmost: admin.mmost,
+                former: admin.former,
+                extrn: admin.extrn,
             };
 
             use diesel::update;

--- a/src/projects/models.rs
+++ b/src/projects/models.rs
@@ -11,6 +11,7 @@ pub struct Project {
     pub owner_id: i32,
     pub active: bool,
     pub repos: String,
+    pub extrn: bool,
 }
 
 #[derive(Debug, Default, Clone, FromForm, Insertable, AsChangeset)]
@@ -21,6 +22,7 @@ pub struct NewProject {
     pub homepage: Option<String>,
     pub owner_id: i32,
     pub repos: String,
+    pub extrn: bool,
 }
 
 #[derive(Debug, PartialEq, Clone, Queryable, Associations, Identifiable)]

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -93,6 +93,8 @@ table! {
         joined_on -> Timestamp,
         tier -> Integer,
         mmost -> Text,
+        former -> Bool,
+        extrn -> Bool,
     }
 }
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -61,6 +61,7 @@ table! {
         owner_id -> Integer,
         active -> Bool,
         repos -> Text,
+        extrn -> Bool,
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -168,6 +168,8 @@ fn add_user() {
         tier: 0,
         active: true,
         mmost: String::from("JDMM"),
+        former: false,
+        extrn: false,
     };
 
     insert_into(users)

--- a/src/users/models.rs
+++ b/src/users/models.rs
@@ -16,6 +16,8 @@ pub struct User {
     pub joined_on: NaiveDateTime,
     pub tier: i32,
     pub mmost: String,
+    pub former: bool,
+    pub extrn: bool,
 }
 
 #[derive(Debug, Default, Clone, FromForm, Insertable, AsChangeset)]
@@ -30,6 +32,8 @@ pub struct NewUser {
     pub tier: i32,
     pub active: bool,
     pub mmost: String,
+    pub former: bool,
+    pub extrn: bool,
 }
 
 use crate::models::Attendable;

--- a/templates/project/edit-project.html
+++ b/templates/project/edit-project.html
@@ -51,6 +51,8 @@
         <label class="custom-control-label" for="extrn">External Project</label>
     </div>
 
+    <br>
+
     <input type="hidden" name="repos" value="[]">
     <button type="submit" class="btn btn-primary">Submit</button>
 </form>

--- a/templates/project/edit-project.html
+++ b/templates/project/edit-project.html
@@ -45,6 +45,12 @@
         <button type="button" class="btn btn-secondary" onclick="add_repo(); void(0)">Add Repo</button>
     </div>
 
+    <div class="custom-control custom-switch">
+        <input type="checkbox" class="custom-control-input" id="extrn" name="extrn" {% if project.extrn %} checked
+            {% endif %}>
+        <label class="custom-control-label" for="extrn">External Project</label>
+    </div>
+
     <input type="hidden" name="repos" value="[]">
     <button type="submit" class="btn btn-primary">Submit</button>
 </form>

--- a/templates/project/new-project.html
+++ b/templates/project/new-project.html
@@ -33,6 +33,13 @@
         <button type="button" class="btn btn-secondary" onclick="add_repo(); void(0)">Add Repo</button>
     </div>
 
+    <div class="custom-control custom-switch">
+        <input type="checkbox" class="custom-control-input" id="extrn" name="extrn">
+        <label class="custom-control-label" for="extrn">External Project</label>
+    </div>
+
+    <br>
+
     <input type="hidden" name="owner_id" value="0">
     <input type="hidden" name="repos" value="[]">
     <button type="submit" class="btn btn-primary">Submit</button>

--- a/templates/project/project.html
+++ b/templates/project/project.html
@@ -37,7 +37,7 @@
 
 <p>{{ project.description|e|md|safe }}</p>
 
-<div>External project?: {{ project.extrn }}</div>
+<p>External project?: {{ project.extrn }}</p>
 
 <div id="repos">
     <h3>Repos</h3>

--- a/templates/project/project.html
+++ b/templates/project/project.html
@@ -37,6 +37,8 @@
 
 <p>{{ project.description|e|md|safe }}</p>
 
+<div>External project?: {{ project.extrn }}</div>
+
 <div id="repos">
     <h3>Repos</h3>
     <ul>

--- a/templates/user/edit-user.html
+++ b/templates/user/edit-user.html
@@ -46,8 +46,9 @@
     <div class="custom-control custom-switch">
         <input type="checkbox" class="custom-control-input" id="extrn" name="extrn" {% if user.extrn %} checked
             {% endif %}>
-        <label class="custom-control-label" for="extrn">External Project</label>
+        <label class="custom-control-label" for="extrn">External Member</label>
     </div>
+    <br>
     {% match logged_in %}
     {% when Some with (u) %}
     {% if u.tier > 1 && user.id != 0 %}

--- a/templates/user/edit-user.html
+++ b/templates/user/edit-user.html
@@ -38,6 +38,16 @@
             {% endif %}>
         <label class="custom-control-label" for="active">Active User</label>
     </div>
+    <div class="custom-control custom-switch">
+        <input type="checkbox" class="custom-control-input" id="former" name="former" {% if user.former %} checked
+            {% endif %}>
+        <label class="custom-control-label" for="former">Former Member</label>
+    </div>
+    <div class="custom-control custom-switch">
+        <input type="checkbox" class="custom-control-input" id="extrn" name="extrn" {% if user.extrn %} checked
+            {% endif %}>
+        <label class="custom-control-label" for="extrn">External Project</label>
+    </div>
     {% match logged_in %}
     {% when Some with (u) %}
     {% if u.tier > 1 && user.id != 0 %}

--- a/templates/user/user.html
+++ b/templates/user/user.html
@@ -27,6 +27,8 @@
     <div>Github: <a href="https://github.com/{{ user.handle }}" target="_blank">{{ user.handle }}</a></div>
     <div>Mattermost: {{ user.mmost }}</div>
     <div>Member since: {{ user.joined_on }}</div>
+    <div>Former Member?: {{ user.former }}</div>
+    <div>Working on external project?: {{ user.extrn }}</div>
 
     <h2>Bio</h2>
     <p>{{ user.bio|e|md|safe }}</p>

--- a/templates/user/user.html
+++ b/templates/user/user.html
@@ -28,7 +28,7 @@
     <div>Mattermost: {{ user.mmost }}</div>
     <div>Member since: {{ user.joined_on }}</div>
     <div>Former Member?: {{ user.former }}</div>
-    <div>Working on external project?: {{ user.extrn }}</div>
+    <div>RCOS Member?: {{ !user.extrn }}</div>
 
     <h2>Bio</h2>
     <p>{{ user.bio|e|md|safe }}</p>


### PR DESCRIPTION
**Related Issues**
#21 #61 (as mentioned by @rushsteve1 )

**Describe the Changes**
I added .former and .extrn variables to the User and NewUser structs which flags the user as a former member or a member who is not part of RCOS. The appropriate SQL and .html files have also been modified to include this information. Update: I have now added an external flag to projects using the same method.

**Still To Do**
The format and placement of these flags on their respective webpages can me modified in the future, right now they're placeholders and look ugly.

**Problems**
None related to my code. I found a separate bug that predates my changes regarding the user.html page and dashboard.html page not displaying correctly when adding a project. Issue will be opened up in the issue board.

**Acknowledgements**
@rushsteve1  and @BrianMejia assisted me with understanding Rust, HTML, and SQLite, and generally answering questions when I encountered errors.
