### PR TITLE
Fix to delete project bug

### DIFF
--- a/src/projects/handlers.rs
+++ b/src/projects/handlers.rs
@@ -166,7 +166,6 @@ pub fn project_delete(conn: ObservDbConn, l: UserGuard, h: i32) -> Result<Redire
         delete(relation_project_user.filter(project_id.eq(h)))
             .execute(&*conn)
             .expect("Failed to delete relations from database");
-        use crate::schema::projects::dsl::*;
         delete(projects.find(h))
             .execute(&*conn)
             .expect("Failed to delete project from database");


### PR DESCRIPTION
**Related Issues**
This is in relation to #73 

**Describe the Changes**
Fixed Issue #73 Delete Project is not deleting the project. We identified that AdminGuard instead of UserGuard was being used when verifying deletion of a project. We changed the type of guard and added code to check that the user is the one who created the project in the first place.

**Still To Do**
Figure out if this issue is related to Issue #74 

**Problems**
None

**Acknowledgements**
@rushsteve1 helped me to make the changes needed for the fix. @DowdSean and @bernep were investigating the issue before me and took most of the steps leading up to identifying issue.
