### PR TITLE
Improve password hashing API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ askama-filters = { version = "^0.1.1", features = ["markdown"] }
 chrono = { version = "^0.4.6", features = ["serde"] }
 diesel = { version = "^1.4.2", features = ["sqlite", "chrono"] }
 diesel_migrations = "^1.4.0"
+diesel-derive-newtype = "^0.1.2"
 rand = "^0.7.0"
 reqwest = "^0.9.16"
 rocket = "^0.4.1"

--- a/src/auth/crypto.rs
+++ b/src/auth/crypto.rs
@@ -9,33 +9,76 @@ use ring::{digest, pbkdf2};
 const N_ITER: u32 = 100000;
 const CRE_LEN: usize = digest::SHA512_256_OUTPUT_LEN;
 
-/// Generate password salt
-///
-/// This function generates **an invalid string** of bytes that is a salt
-/// to be used when hashing a password.
+/// This is a simple type around String to alert
+/// other developers that this is an unsafe string.
 /// Do not attempt to parse or otherwise do anything with this string.
-pub fn gen_salt() -> String {
+/// It is exclusively used by the cryptography systems for database
+/// compatability within `HashedPassword` and the `User` struct.
+pub type UnsafeBinaryString = String;
+
+/// Structure containing the result of a cryptographically hashed password.
+/// This allows us to handle them more safely and avoid using unsafe
+/// strings as much as possible.
+/// This also makes the resulting API more elegant and easier to use.
+///
+/// The methods on this struct are unsafe code
+/// (currently the only in the project)
+/// due to Diesel requiring that the password hash and salt to be strings.
+pub struct HashedPassword {
+    pass: Vec<u8>,
+    salt: Vec<u8>,
+}
+
+impl HashedPassword {
+    /// Returns the hashed password as an `UnsafeBinaryString`
+    ///
+    /// This function returns an **invalid string** of bytes.
+    /// Do not attempt to parse or otherwise do anything with this string.
+    pub fn pass(&self) -> UnsafeBinaryString {
+        unsafe { String::from_utf8_unchecked(self.pass.clone()) }
+    }
+
+    /// Returns the password's salt as an `UnsafeBinaryString`
+    ///
+    /// This function returns an **invalid string** of bytes.
+    /// Do not attempt to parse or otherwise do anything with this string.
+    pub fn salt(&self) -> UnsafeBinaryString {
+        unsafe { String::from_utf8_unchecked(self.salt.clone()) }
+    }
+
+    /// Returns the a tuple containing both the password hash and the salt,
+    /// in that order. Useful for pattern matching.
+    ///
+    /// This function returns an **invalid string** of bytes.
+    /// Do not attempt to parse or otherwise do anything with this string.
+    pub fn both(&self) -> (UnsafeBinaryString, UnsafeBinaryString) {
+        (self.pass(), self.salt())
+    }
+}
+
+/// Encrypt a password and return a `HashedPassword` struct
+/// which can be used to get the hash and salt directly.
+pub fn hash_password(pass: String) -> HashedPassword {
+    // Generate the password salt
     let rng = SystemRandom::new();
     let mut salt = [0u8; CRE_LEN];
     rng.fill(&mut salt).unwrap();
-    unsafe { String::from_utf8_unchecked(salt.to_vec()) }
-}
 
-/// Encrypt a password using a salt
-///
-/// Using a salt generate by `gen_salt` this function encrypts a password.
-/// This function **returns an invalid string** of bytes.
-/// Do not attempt to parse or otherwise do anything with this string.
-pub fn hash_password(pass: String, salt: &String) -> String {
+    // Derive the password hash
     let mut out = [0u8; CRE_LEN];
     pbkdf2::derive(
         &digest::SHA512,
         N_ITER,
-        salt.as_bytes(),
+        &salt as &[u8],
         pass.as_bytes(),
         &mut out,
     );
-    unsafe { String::from_utf8_unchecked(out.to_vec()) }
+
+    // Return a HashedPassword struct
+    HashedPassword {
+        pass: out.to_vec(),
+        salt: salt.to_vec(),
+    }
 }
 
 /// Verify that a password is correct
@@ -44,7 +87,11 @@ pub fn hash_password(pass: String, salt: &String) -> String {
 /// verifies that the password is correct.
 ///
 /// You should never directly compare two hashed passwords.
-pub fn verify_password(pass: String, compare_to: String, salt: &String) -> bool {
+pub fn verify_password(
+    pass: String,
+    compare_to: UnsafeBinaryString,
+    salt: UnsafeBinaryString,
+) -> bool {
     pbkdf2::verify(
         &digest::SHA512,
         N_ITER,

--- a/src/auth/handlers.rs
+++ b/src/auth/handlers.rs
@@ -46,7 +46,7 @@ impl From<SignUpForm> for NewUser {
         newuser.handle = f.handle;
         newuser.mmost = f.mmost;
 
-        let (pass, salt) = hash_password(f.password).both();
+        let (pass, salt) = hash_password(f.password);
         newuser.salt = salt;
         newuser.password_hash = pass;
 

--- a/src/auth/handlers.rs
+++ b/src/auth/handlers.rs
@@ -46,9 +46,9 @@ impl From<SignUpForm> for NewUser {
         newuser.handle = f.handle;
         newuser.mmost = f.mmost;
 
-        let newsalt = gen_salt();
-        newuser.salt = newsalt.clone();
-        newuser.password_hash = hash_password(f.password, &newsalt);
+        let (pass, salt) = hash_password(f.password).both();
+        newuser.salt = salt;
+        newuser.password_hash = pass;
 
         newuser.tier = 0;
         newuser.active = true;
@@ -180,7 +180,7 @@ pub fn login_post(
         .expect("Failed to get user from database")
     {
         // Verify the password
-        if verify_password(creds.password, user.password_hash, &user.salt) {
+        if verify_password(creds.password, user.password_hash, user.salt) {
             cookies.add_private(Cookie::new("user_id", format!("{}", user.id)));
             Redirect::to(to)
         } else {

--- a/src/fairings.rs
+++ b/src/fairings.rs
@@ -97,7 +97,7 @@ impl Fairing for AdminCheck {
                 pass
             );
 
-            let (phash, psalt) = hash_password(pass).both();
+            let (phash, psalt) = hash_password(pass);
 
             // Needs to be a NewUser for set() so create it
             let nu = NewUser {

--- a/src/fairings.rs
+++ b/src/fairings.rs
@@ -97,8 +97,7 @@ impl Fairing for AdminCheck {
                 pass
             );
 
-            let psalt = gen_salt();
-            let phash = hash_password(pass, &psalt);
+            let (phash, psalt) = hash_password(pass).both();
 
             // Needs to be a NewUser for set() so create it
             let nu = NewUser {

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,8 @@ extern crate rust_embed;
 extern crate serde_derive;
 #[macro_use]
 extern crate diesel_migrations;
+#[macro_use]
+extern crate diesel_derive_newtype;
 
 // Module files
 mod fairings;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -156,8 +156,8 @@ fn add_user() {
 
     use crate::schema::users::dsl::*;
     let pass = String::from("thisisapassword");
-    let psalt = gen_salt();
-    let phash = hash_password(pass, &psalt);
+
+    let (phash, psalt) = hash_password(pass).both();
 
     let nu = NewUser {
         real_name: String::from("John Doe"),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -157,7 +157,7 @@ fn add_user() {
     use crate::schema::users::dsl::*;
     let pass = String::from("thisisapassword");
 
-    let (phash, psalt) = hash_password(pass).both();
+    let (phash, psalt) = hash_password(pass);
 
     let nu = NewUser {
         real_name: String::from("John Doe"),

--- a/src/users/handlers.rs
+++ b/src/users/handlers.rs
@@ -84,8 +84,9 @@ pub fn user_edit_put(
             edituser.salt = esalt;
             edituser.password_hash = phash;
         } else {
-            edituser.salt = gen_salt();
-            edituser.password_hash = hash_password(edituser.password_hash, &edituser.salt);
+            let (phash, psalt) = hash_password(edituser.password_hash).both();
+            edituser.password_hash = phash;
+            edituser.salt = psalt;
         }
 
         // if the logged in user can't change tiers

--- a/src/users/handlers.rs
+++ b/src/users/handlers.rs
@@ -84,7 +84,7 @@ pub fn user_edit_put(
             edituser.salt = esalt;
             edituser.password_hash = phash;
         } else {
-            let (phash, psalt) = hash_password(edituser.password_hash).both();
+            let (phash, psalt) = hash_password(edituser.password_hash);
             edituser.password_hash = phash;
             edituser.salt = psalt;
         }

--- a/src/users/models.rs
+++ b/src/users/models.rs
@@ -1,3 +1,4 @@
+use crate::auth::crypto::UnsafeBinaryString;
 use crate::schema::*;
 use chrono::NaiveDateTime;
 
@@ -8,9 +9,9 @@ pub struct User {
     pub handle: String,
     pub email: String,
     #[serde(skip)]
-    pub password_hash: String,
+    pub password_hash: UnsafeBinaryString,
     #[serde(skip)]
-    pub salt: String,
+    pub salt: UnsafeBinaryString,
     pub bio: String,
     pub active: bool,
     pub joined_on: NaiveDateTime,
@@ -25,8 +26,8 @@ pub struct User {
 pub struct NewUser {
     pub real_name: String,
     pub handle: String,
-    pub password_hash: String,
-    pub salt: String,
+    pub password_hash: UnsafeBinaryString,
+    pub salt: UnsafeBinaryString,
     pub bio: String,
     pub email: String,
     pub tier: i32,


### PR DESCRIPTION
I had been unhappy with the way that we interacted with the password hashing utilities for a while now so decided to finally get around to do something about it.

**Related Issues**
(I never made an issue for this, I should have)

**Describe the Changes**

This commit removes `gen_salt()` and merges it into `hash_password()` and introduces the `HashedPassword` struct which is used to represent a hashed password in a safer manner.

I also added a simple type def `UnsafeBinaryString` to make it more obvious that the output of a password hashing is not a valid string but we are treating it like one.

**Still To Do**
Ensure that the changes do not break any existing password hashes in the database. It should be fine since the actual password hashing and verifying code has not changed.

**Problems**
`HashedPassword` and `UnsafeBinaryString` were both introduced to make working with the API somewhat safer. But it still ends up using unsafe `String`s and uses unsafe code, which I would like to avoid.
It might be possible to have Diesel understand a `Vec<u8>` or similar and handle it in the database. But I do not know how.

Which is why I am making this as a PR instead of just pushing it like I usually do. Some feedback on the new API and any suggestions on tightening it up and possibly removing the unsafe code would be awesome.

So that said @BrianMejia would you be willing to review this for me?