### PR TITLE
Added a Modifiable Proposal URL for Projects

### DIFF
--- a/migrations/sqlite/2019-10-29-197652_alter_projects_proposal/down.sql
+++ b/migrations/sqlite/2019-10-29-197652_alter_projects_proposal/down.sql
@@ -1,0 +1,1 @@
+-- This file should undo anything in `up.sql`

--- a/migrations/sqlite/2019-10-29-197652_alter_projects_proposal/up.sql
+++ b/migrations/sqlite/2019-10-29-197652_alter_projects_proposal/up.sql
@@ -1,0 +1,2 @@
+-- Optional homepage of the project
+ALTER TABLE projects ADD proposal TEXT;

--- a/src/projects/models.rs
+++ b/src/projects/models.rs
@@ -13,14 +13,17 @@ pub struct Project {
     pub name: String,
     /// Description of the Project
     pub description: String,
-    /// Link if the project has their own website
+    /// Link if the project has its own website
     pub homepage: Option<String>,
+    /// Link if the project has a proposal document
+    pub proposal: Option<String>,
     /// ID of the student that owns the project
     pub owner_id: i32,
     /// Checks if this is a project that is currently being worked on this semester
     pub active: bool,
     /// Link the Project repository
     pub repos: String,
+    /// External (Non-RCOS) Project Flag
     pub extrn: bool,
 }
 
@@ -34,12 +37,15 @@ pub struct NewProject {
     pub name: String,
     /// Description of the Project
     pub description: String,
-    /// Puts in URL for the projects website if it has one
+    /// Puts in URL for the project's website if it has one
     pub homepage: Option<String>,
+    /// Puts in URL for the project's proposal if it has one
+    pub proposal: Option<String>,
     /// The ID of the student who creates and owns the new project
     pub owner_id: i32,
     /// Link to the Project Repository
     pub repos: String,
+    /// External (Non-RCOS) Project Flag
     pub extrn: bool,
 }
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -58,6 +58,7 @@ table! {
         name -> Text,
         description -> Text,
         homepage -> Nullable<Text>,
+        proposal -> Nullable<Text>,
         owner_id -> Integer,
         active -> Bool,
         repos -> Text,

--- a/templates/project/edit-project.html
+++ b/templates/project/edit-project.html
@@ -33,7 +33,7 @@
     </div>
 
     <div class="form-group">
-        <label for="owner_id">Project Owner <noscript>(As a JSON array)</noscript></label>
+        <label for="owner_id">Project Owner</label>
         <select name="owner_id" class="custom-select" value="{{ project.owner_id }}">
             {% for user in all_users %}
             <option value="{{ user.id }}" {% if project.owner_id == user.id %} selected {% endif %}>

--- a/templates/project/edit-project.html
+++ b/templates/project/edit-project.html
@@ -18,7 +18,13 @@
     <div class="form-group">
         <label for="homepage">Project Website</label>
         <input type="url" name="homepage" class="form-control"
-            value="{% match project.homepage %}{% when Some with (h) %}{{ h }}{% when None%}{% endmatch %}">
+            value="{% match project.homepage %}{% when Some with (h) %}{{ h }}{% when None %}{% endmatch %}">
+    </div>
+
+    <div class="form-group">
+        <label for="proposal">Project Proposal</label>
+        <input type="url" name="proposal" class="form-control"
+            value="{% match project.proposal %}{% when Some with (h) %}{{ h }}{% when None %}{% endmatch %}">
     </div>
 
     <div class="form-group">
@@ -27,7 +33,7 @@
     </div>
 
     <div class="form-group">
-        <label for="owner_id"></label>
+        <label for="owner_id">Project Owner <noscript>(As a JSON array)</noscript></label>
         <select name="owner_id" class="custom-select" value="{{ project.owner_id }}">
             {% for user in all_users %}
             <option value="{{ user.id }}" {% if project.owner_id == user.id %} selected {% endif %}>

--- a/templates/project/project.html
+++ b/templates/project/project.html
@@ -29,9 +29,18 @@
 {% endblock %}
 
 {% block content %}
+
 {% match project.homepage %}
 {% when Some with (val) %}
 <a href="{{ val }}">Homepage</a>
+{% when None %}
+{% endmatch %}
+
+<br>
+
+{% match project.proposal %}
+{% when Some with (val) %}
+<a href="{{ val }}">Proposal Document</a>
 {% when None %}
 {% endmatch %}
 


### PR DESCRIPTION
**Related Issues**
#59 

**Describe the Changes**
I've added a new variable to the projects struct (project.proposal), and I've made it modifiable. Essentially we can now add a link to proposal documents on the project page.

**Still To Do**
We need visual improvements still, as mentioned in issue #69 

**Problems**
No. I actually fixed a few minor things as well (i.e. added a Label to the Project Leader section of the Edit Project page).

**Acknowledgements**
@rushsteve1 for basic questions and assistance.
