### PR TITLE
User Page Updated

### DIFF
--- a/templates/user/user.html
+++ b/templates/user/user.html
@@ -29,7 +29,15 @@
     <div>Member since: {{ user.joined_on }}</div>
     <div>Former Member?: {{ user.former }}</div>
     <div>RCOS Member?: {{ !user.extrn }}</div>
-
+	
+	{% if user.tier == 1 %}
+	<div> User Status: Mentor </div>
+	{% else if user.tier == 2 %}
+	<div> User Status: Coordinator </div>
+	{% else if user.tier == 3 %}
+	<div> User Status: Administrator </div>
+	{% endif %}
+	
     <h2>Bio</h2>
     <p>{{ user.bio|e|md|safe }}</p>
 


### PR DESCRIPTION
**Related Issues**
This is not related to any current issues

**Describe the Changes**
Added a user status to the indivual user page so when someone looks at a users page it will tell them 1: They are a mentor, 2: They are an course coordinator, 3: They are the Admin. If the user is none of these things User Status will not appear on there user page
*Still To Do**
Still need to add a flag if they are a former member or someone that is not related to RCOS

**Problems**
At the moment no

**Acknowledgements**
Steven helped me
