### PR TITLE
Character limit

### DIFF
--- a/src/auth/handlers.rs
+++ b/src/auth/handlers.rs
@@ -68,7 +68,9 @@ impl From<SignUpForm> for NewUser {
 /// If all goes well then it redirects to `/` otherwise back to the same page.
 #[post("/signup", data = "<form>")]
 pub fn signup_post(conn: ObservDbConn, mut cookies: Cookies, form: Form<SignUpForm>) -> Redirect {
-    let form = form.into_inner();
+    let mut form = form.into_inner();
+	form.handle.truncate(39);
+	form.mmost.truncate(22);
     // Make sure the password is properly repeated
     if form.password != form.password_repeat {
         return Redirect::to(format!("/signup?e={}", FormError::PasswordMismatch));

--- a/src/auth/handlers.rs
+++ b/src/auth/handlers.rs
@@ -69,8 +69,8 @@ impl From<SignUpForm> for NewUser {
 #[post("/signup", data = "<form>")]
 pub fn signup_post(conn: ObservDbConn, mut cookies: Cookies, form: Form<SignUpForm>) -> Redirect {
     let mut form = form.into_inner();
-	form.handle.truncate(39);
-	form.mmost.truncate(22);
+    form.handle.truncate(39);
+    form.mmost.truncate(22);
     // Make sure the password is properly repeated
     if form.password != form.password_repeat {
         return Redirect::to(format!("/signup?e={}", FormError::PasswordMismatch));

--- a/src/groups/handlers.rs
+++ b/src/groups/handlers.rs
@@ -124,17 +124,20 @@ pub fn meeting_new_post(
         .first(&*conn)
         .expect("Failed to get group from database");
 
-	if l.0.tier > 1 || l.0.id == g.owner_id || (l.0.id > 0 && group_users(&*conn, &g).contains(&l.0) && g.id > 0) {
-		use crate::schema::meetings::dsl::*;
-		let mut newmeeting = newmeeting.into_inner();
-		newmeeting.group_id = gid;
-		newmeeting.code = attendance_code(&*conn);
+    if l.0.tier > 1
+        || l.0.id == g.owner_id
+        || (l.0.id > 0 && group_users(&*conn, &g).contains(&l.0) && g.id > 0)
+    {
+        use crate::schema::meetings::dsl::*;
+        let mut newmeeting = newmeeting.into_inner();
+        newmeeting.group_id = gid;
+        newmeeting.code = attendance_code(&*conn);
 
-		insert_into(meetings)
-			.values(&newmeeting)
-			.execute(&*conn)
-			.expect("Failed to insert meeting into database");
-	}
+        insert_into(meetings)
+            .values(&newmeeting)
+            .execute(&*conn)
+            .expect("Failed to insert meeting into database");
+    }
     Redirect::to(format!("/groups/{}", gid))
 }
 

--- a/src/projects/handlers.rs
+++ b/src/projects/handlers.rs
@@ -88,6 +88,7 @@ pub fn project_new_post(
     newproject: Form<NewProject>,
 ) -> Redirect {
     let mut newproject = newproject.into_inner();
+	newproject.name.truncate(50); //set a character limit to a project
     newproject.owner_id = l.0.id; // set owner to be the person who created the project
 
     // handles the fact that projects can have multiple repos
@@ -171,6 +172,8 @@ pub fn project_edit_put(
     use crate::schema::projects::dsl::*;
 
     let mut editproject = editproject.into_inner();
+	editproject.name.truncate(50);
+	
     editproject.repos = serde_json::to_string(
         &serde_json::from_str::<Vec<String>>(&editproject.repos)
             .unwrap()

--- a/src/projects/handlers.rs
+++ b/src/projects/handlers.rs
@@ -88,7 +88,7 @@ pub fn project_new_post(
     newproject: Form<NewProject>,
 ) -> Redirect {
     let mut newproject = newproject.into_inner();
-	newproject.name.truncate(50); //set a character limit to a project
+    newproject.name.truncate(50); //set a character limit to a project
     newproject.owner_id = l.0.id; // set owner to be the person who created the project
 
     // handles the fact that projects can have multiple repos
@@ -172,8 +172,8 @@ pub fn project_edit_put(
     use crate::schema::projects::dsl::*;
 
     let mut editproject = editproject.into_inner();
-	editproject.name.truncate(50);
-	
+    editproject.name.truncate(50);
+
     editproject.repos = serde_json::to_string(
         &serde_json::from_str::<Vec<String>>(&editproject.repos)
             .unwrap()

--- a/templates/auth/signup.html
+++ b/templates/auth/signup.html
@@ -28,11 +28,11 @@
     </div>
     <div class="form-group">
         <label for="handle">GitHub Handle</label>
-        <input type="text" name="handle" class="form-control" required>
+        <input type="text" name="handle" class="form-control" maxlength = "39" required>
     </div>
     <div class="form-group">
         <label for="mmost">Mattermost Handle</label>
-        <input type="text" name="mmost" class="form-control" required>
+        <input type="text" name="mmost" class="form-control" maxlength = "22" required>
     </div>
     <button type="submit" class="btn btn-primary">Sign Up</button>
 </form>

--- a/templates/group/new-group.html
+++ b/templates/group/new-group.html
@@ -11,7 +11,7 @@
 <form method="POST">
     <div class="form-group">
         <label for="name">Group Name</label>
-        <input type="text" name="name" class="form-control" required autofocus>
+        <input type="text" name="name" class="form-control" maxlength = "50" "required autofocus>
     </div>
     <div class="form-group">
         <label for="location">Meeting Location</label>

--- a/templates/project/edit-project.html
+++ b/templates/project/edit-project.html
@@ -12,7 +12,7 @@
 <form method="PUT" action="/projects/{{ project.id }}">
     <div class="form-group">
         <label for="name">Project Name</label>
-        <input type="text" name="name" class="form-control" value="{{ project.name }}" required autofocus>
+        <input type="text" name="name" class="form-control" value="{{ project.name }}" maxlength = "50" required autofocus>
     </div>
 
     <div class="form-group">

--- a/templates/project/new-project.html
+++ b/templates/project/new-project.html
@@ -12,7 +12,7 @@
 <form method="POST">
     <div class="form-group">
         <label for="name">Project Name</label>
-        <input type="text" name="name" class="form-control" required autofocus>
+        <input type="text" name="name" class="form-control" maxlength = "50" required autofocus>
     </div>
 
     <div class="form-group">

--- a/templates/user/edit-user.html
+++ b/templates/user/edit-user.html
@@ -23,11 +23,11 @@
     </div>
     <div class="form-group">
         <label for="handle">GitHub Handle</label>
-        <input type="text" name="handle" class="form-control" value="{{ user.handle }}" required>
+        <input type="text" name="handle" class="form-control" value="{{ user.handle }}" maxlength = "39" required>
     </div>
     <div class="form-group">
         <label for="mmost">Mattermost Handle</label>
-        <input type="text" name="mmost" class="form-control" value="{{ user.mmost }}" required>
+        <input type="text" name="mmost" class="form-control" value="{{ user.mmost }}" maxlength = "22" required>
     </div>
     <div class="form-group">
         <label for="bio">Your Bio</label>


### PR DESCRIPTION
Added character limit to user names Github 39 character limit to match actual Github user limit, Mattermost user name limit 22 to match its character limit. A soft 50 character limit for email actual names and project names. So they can't go on infinitely.

**Related Issues**
No other issues related to this were fixed

**Describe the Changes**
Input max length into the html and rust source code so github user name is a 39 character limit Mattermost 22 character limit and everything else was given a 50 character limit. So you can not input more characters than that.

**Still To Do**
Fine tune the 50 character limit see if maybe we can make them a bit shorter

**Problems**
None that I can find

**Acknowledgements**
Darrian and Steven helped me
