### PR TITLE
Active filter for users and projects

### DIFF
--- a/src/projects/models.rs
+++ b/src/projects/models.rs
@@ -43,6 +43,8 @@ pub struct NewProject {
     pub proposal: Option<String>,
     /// The ID of the student who creates and owns the new project
     pub owner_id: i32,
+    /// Checks if this is a project that is currently being worked on this semester
+    pub active: bool,
     /// Link to the Project Repository
     pub repos: String,
     /// External (Non-RCOS) Project Flag

--- a/src/projects/templates.rs
+++ b/src/projects/templates.rs
@@ -55,6 +55,8 @@ pub struct EditProjectTemplate {
 pub struct ProjectsListTemplate {
     pub logged_in: OptUser,
     pub projects: Vec<Project>,
+    pub search_term: String,
+    pub inactive: bool
 }
 
 /// Template shown when a student wants to join a project

--- a/src/users/handlers.rs
+++ b/src/users/handlers.rs
@@ -117,32 +117,52 @@ pub fn user_delete(conn: ObservDbConn, _l: AdminGuard, h: i32) -> Redirect {
     Redirect::to("/users")
 }
 
-#[get("/users?<s>")]
-pub fn users(conn: ObservDbConn, l: MaybeLoggedIn, s: Option<String>) -> UsersListTemplate {
+#[get("/users?<s>&<a>")]
+pub fn users(conn: ObservDbConn, l: MaybeLoggedIn, s: Option<String>, a: Option<bool>) -> UsersListTemplate {
     UsersListTemplate {
         logged_in: l.user(),
-        users: filter_users(&*conn, s),
+        search_term: s.clone().unwrap_or_else(String::new),
+        users: filter_users(&*conn, s, a),
+        inactive: a.unwrap_or(false)
     }
 }
 
-#[get("/users.json?<s>")]
-pub fn users_json(conn: ObservDbConn, s: Option<String>) -> Json<Vec<User>> {
-    Json(filter_users(&*conn, s))
+#[get("/users.json?<s>&<a>")]
+pub fn users_json(conn: ObservDbConn, s: Option<String>, a: Option<bool>) -> Json<Vec<User>> {
+    Json(filter_users(&*conn, s, a))
 }
 
-pub fn filter_users(conn: &SqliteConnection, term: Option<String>) -> Vec<User> {
+pub fn filter_users(conn: &SqliteConnection, term: Option<String>, inact: Option<bool>) -> Vec<User> {
     use crate::schema::users::dsl::*;
+
+    let afilter = active.eq(true).and(former.eq(false));
 
     if let Some(term) = term {
         let sterm = format!("%{}%", term);
         let email_term = format!("%{}@", term);
+
         let filter = real_name
             .like(&sterm)
             .or(email.like(&email_term))
             .or(handle.like(&sterm));
-        users.filter(filter).load(conn)
+
+        match inact {
+            Some(true) => {
+                users.filter(filter).load(conn)
+            },
+            Some(false) | None => {
+                users.filter(filter.and(afilter)).load(conn)
+            }
+        }
     } else {
-        users.load(conn)
+        match inact {
+            Some(true) => {
+                users.load(conn)
+            },
+            Some(false) | None => {
+                users.filter(afilter).load(conn)
+            }
+        }
     }
     .expect("Failed to get users")
 }

--- a/src/users/templates.rs
+++ b/src/users/templates.rs
@@ -30,4 +30,6 @@ pub struct EditUserTemplate {
 pub struct UsersListTemplate {
     pub logged_in: OptUser,
     pub users: Vec<User>,
+    pub search_term: String,
+    pub inactive: bool
 }

--- a/templates/project/edit-project.html
+++ b/templates/project/edit-project.html
@@ -52,6 +52,12 @@
     </div>
 
     <div class="custom-control custom-switch">
+        <input type="checkbox" class="custom-control-input" id="active" name="active" {% if project.active %} checked
+            {% endif %}>
+        <label class="custom-control-label" for="active">Active</label>
+    </div>
+
+    <div class="custom-control custom-switch">
         <input type="checkbox" class="custom-control-input" id="extrn" name="extrn" {% if project.extrn %} checked
             {% endif %}>
         <label class="custom-control-label" for="extrn">External Project</label>

--- a/templates/project/new-project.html
+++ b/templates/project/new-project.html
@@ -42,6 +42,7 @@
 
     <input type="hidden" name="owner_id" value="0">
     <input type="hidden" name="repos" value="[]">
+    <input type="hidden" name="active" value="true">
     <button type="submit" class="btn btn-primary">Submit</button>
 </form>
 {% endblock %}

--- a/templates/project/projects-list.html
+++ b/templates/project/projects-list.html
@@ -8,6 +8,18 @@
 {% endblock %}
 
 {% block tools %}
+<form method="GET" class="form-inline">
+    <div class="input-group mb-3">
+        <div class="custom-control custom-switch">
+            <input type="checkbox" class="custom-control-input" id="a" name="a" {% if inactive %}checked{% endif %}>
+            <label class="custom-control-label" for="a">Show Inactive</label>
+        </div>
+        <input type="text" name="s" placeholder="Search">
+        <div class="input-group-append">
+            <button type="submit" class="btn btn-outline-secondary">Search</button>
+        </div>
+    </div>
+</form>
 {% match logged_in%}
 {% when Some with (u) %}
 <div class="btn-group">
@@ -15,14 +27,6 @@
 </div>
 {% when None %}
 {% endmatch %}
-<form method="GET" class="form-inline">
-    <div class="input-group mb-3">
-        <input type="text" name="s" placeholder="Search">
-        <div class="input-group-append">
-            <button type="submit" class="btn btn-outline-secondary">Search</button>
-        </div>
-    </div>
-</form>
 {% endblock %}
 
 {% block content %}

--- a/templates/user/users-list.html
+++ b/templates/user/users-list.html
@@ -10,7 +10,11 @@
 {% block tools %}
 <form method="GET" class="mr-2">
     <div class="input-group mb-3">
-        <input type="text" name="s" placeholder="Search">
+        <div class="custom-control custom-switch">
+            <input type="checkbox" class="custom-control-input" id="a" name="a" {% if inactive %}checked{% endif %}>
+            <label class="custom-control-label" for="a">Show Inactive</label>
+        </div>
+        <input type="text" name="s" placeholder="Search" value="{{ search_term }}">
         <div class="input-group-append">
             <button type="submit" class="btn btn-outline-secondary">Search</button>
         </div>


### PR DESCRIPTION
**Related Issues**
I never opened an issue for this even though I should have. Whoops...

**Describe the Changes**
The users and projects list pages now automatically filter out former and inactive entries, and there is now a toggle that can enable showing them again.

**Still To Do**
Perhaps add some simple banners to the user and project pages to alert others of their status.

**Problems**
There is a bit of repetition in the Rust code, but nothing major. It was just simpler to do it this way since the type system complained otherwise.

**Note**
I have decided that in an attempt to improve code-quality I am going to stop just pushing to master and will instead be making PRs for my changes.