### PR TITLE
Delete relations when necessary

### DIFF
--- a/src/attend/handlers.rs
+++ b/src/attend/handlers.rs
@@ -47,7 +47,7 @@ pub fn attend_post(conn: ObservDbConn, l: UserGuard, code: Form<AttendCode>) -> 
             (Some(m.id()), None, m.group_id())
         };
 
-        let user_in_group = {
+        let user_in_group = if !m.is_event() {
             use crate::schema::relation_group_user::dsl::*;
             relation_group_user
                 .filter(group_id.eq(gid.unwrap()).and(user_id.eq(l.0.id)))
@@ -55,6 +55,8 @@ pub fn attend_post(conn: ObservDbConn, l: UserGuard, code: Form<AttendCode>) -> 
                 .optional()
                 .expect("Failed to get relations from database")
                 .is_some()
+        } else {
+            false
         };
 
         use crate::schema::attendances::dsl::*;

--- a/src/calendar/handlers.rs
+++ b/src/calendar/handlers.rs
@@ -161,6 +161,16 @@ pub fn event_edit_put(
 /// Restricted to Admins.
 #[delete("/calendar/<eid>")]
 pub fn event_delete(conn: ObservDbConn, _l: AdminGuard, eid: i32) -> Redirect {
+
+    // Delete the attendances relations
+    {
+        use crate::schema::attendances::dsl::*;
+        delete(attendances.filter(is_event.eq(true).and(event_id.eq(eid))))
+            .execute(&*conn)
+            .expect("Failed to delete attendances from database");
+    }
+
+    // Delete the event
     use crate::schema::events::dsl::*;
     delete(events.find(eid))
         .execute(&*conn)

--- a/src/groups/handlers.rs
+++ b/src/groups/handlers.rs
@@ -363,14 +363,21 @@ pub fn group_edit_put(
 /// Deletes a group from the database
 #[delete("/groups/<gid>")]
 pub fn group_delete(conn: ObservDbConn, _l: AdminGuard, gid: i32) -> Redirect {
+    // Delete the user relations
     use crate::schema::relation_group_user::dsl::*;
     delete(relation_group_user.filter(group_id.eq(gid)))
         .execute(&*conn)
         .expect("Failed to delete relations from database");
+
+    // Delete the meetings
+    delete_meetings_for(&*conn, gid);
+
+    // Delete the group
     use crate::schema::groups::dsl::*;
     delete(groups.find(gid))
         .execute(&*conn)
         .expect("Failed to delete group from database");
+
     Redirect::to("/groups")
 }
 
@@ -389,4 +396,29 @@ fn group_users(conn: &SqliteConnection, group: &Group) -> Vec<User> {
                 .expect("Failed to get user from database")
         })
         .collect()
+}
+
+fn delete_meetings_for(conn: &SqliteConnection, gid: i32) {
+    use crate::schema::meetings::dsl::*;
+
+    // Get all the meetings
+    let meeting_ids: Vec<i32> = meetings
+        .select(id)
+        .filter(group_id.eq(gid))
+        .load(conn)
+        .expect("Failed to get the meetings from the database");
+
+    for meeting in meeting_ids {
+        // Delete their attendances
+        {
+            use crate::schema::attendances::dsl::*;
+            delete(attendances.filter(is_event.eq(false).and(meeting_id.eq(meeting))))
+                .execute(conn)
+                .expect("Failed to delete attendance from database");
+        }
+        // Delete the meetings
+        delete(meetings.find(meeting))
+            .execute(conn)
+            .expect("Failed to delete meeting from database");
+    }
 }

--- a/src/projects/handlers.rs
+++ b/src/projects/handlers.rs
@@ -201,21 +201,27 @@ pub fn project_edit_put(
 }
 
 /// DELETE handler for `/projects/h`
+///
 /// Deletes relation from all users tied to the project then deletes the project
 
 #[delete("/projects/<h>")]
 pub fn project_delete(conn: ObservDbConn, l: UserGuard, h: i32) -> Result<Redirect, Status> {
     use crate::schema::projects::dsl::*;
+    // Find the project
     let p: Project = projects
         .find(h)
         .first(&*conn)
         .expect("Failed to get project from database");
 
+    // If they are an admin or the project owner
     if l.0.tier > 1 || p.owner_id == l.0.id {
+        // Delete the relations
         use crate::schema::relation_project_user::dsl::*;
         delete(relation_project_user.filter(project_id.eq(h)))
             .execute(&*conn)
             .expect("Failed to delete relations from database");
+
+        // Delete the project
         delete(projects.find(h))
             .execute(&*conn)
             .expect("Failed to delete project from database");

--- a/src/users/handlers.rs
+++ b/src/users/handlers.rs
@@ -109,10 +109,27 @@ pub fn user_edit_put(
 
 #[delete("/users/<h>")]
 pub fn user_delete(conn: ObservDbConn, _l: AdminGuard, h: i32) -> Redirect {
+    // Delete the user
     use crate::schema::users::dsl::*;
     delete(users.find(h))
         .execute(&*conn)
         .expect("Failed to delete user from database");
+
+    // Delete the relations to projects
+    {
+        use crate::schema::relation_project_user::dsl::*;
+        delete(relation_project_user.filter(user_id.eq(h)))
+            .execute(&*conn)
+            .expect("Failed to delete relation from database");
+    }
+
+    // Delete the relations to groups
+    {
+        use crate::schema::relation_group_user::dsl::*;
+        delete(relation_group_user.filter(user_id.eq(h)))
+            .execute(&*conn)
+            .expect("Failed to delete relation from database");
+    }
 
     Redirect::to("/users")
 }

--- a/templates/calendar/event.html
+++ b/templates/calendar/event.html
@@ -13,7 +13,7 @@
     {% when Some with (u) %}
     {% if u.tier > 1 %}
     <a class="btn btn-secondary" href="/calendar/{{ event.id }}/edit">Edit</a>
-    <button typ="delete" class="btn btn-danger">Delete</button>
+    <button type="delete" class="btn btn-danger">Delete</button>
     {% endif %}
     {% when None %}
     {% endmatch %}


### PR DESCRIPTION

**Related Issues**
Fixes #95 and a number of other relations issues that I found.

**Describe the Changes**
While we could rely on the database to cleanup relations, it is safer for us to manually delete relations that have been invalidated since one half of the relation was deleted.
So now when one half of a relation is deleted it makes sure to delete the relation.

**Still To Do**
There may be things that I missed. I think I got everything though.

**Problems**
The database itself can be set to handle these cascading deletions.
But for the sake of database compatibility and just being 100% sure we can do both.

**Acknowledgements**
@DowdSean for finding this problem to begin with.
