### PR TITLE
Added a Meeting Page

### DIFF
--- a/src/attend/models.rs
+++ b/src/attend/models.rs
@@ -3,11 +3,13 @@
 //! Attendance is stored in the `attendance` table where each
 //! row is a time someone attended something.
 
+use crate::models::Meeting;
 use crate::models::User;
 use crate::schema::*;
 
 /// Models an attendance in the database
 #[derive(Debug, PartialEq, Clone, Queryable, Identifiable, Associations, Serialize)]
+#[belongs_to(Meeting)]
 #[belongs_to(User)]
 pub struct Attendance {
     /// ID of the attendance

--- a/src/groups/handlers.rs
+++ b/src/groups/handlers.rs
@@ -126,6 +126,29 @@ pub fn meetings(gid: i32) -> Redirect {
     Redirect::to(format!("/groups/{}", gid))
 }
 
+/// GET handler for `/groups/<gid>/meetings/<mid>`
+#[get("/groups/<gid>/meetings/<mid>")]
+pub fn individual_meetings(conn: ObservDbConn, l: MentorGuard, gid: i32, mid: i32) -> Option<MeetingTemplate> {
+    use crate::schema::groups::dsl::*;
+    let g: Group = groups
+        .find(gid)
+        .first(&*conn)
+        .expect("Failed to get groups from database");
+
+    use crate::schema::meetings::dsl::*;
+    let m: Meeting = meetings
+        .find(mid)
+        .first(&*conn)
+        .expect("Failed to get meetings from database");
+
+    Some(MeetingTemplate {
+        logged_in: Some(l.0),
+        users: group_users(&*conn, &g),
+        group: g,
+        meeting: m,
+    })
+}
+
 /// GET handler for `/groups/<gid>/meetings.json`
 #[get("/groups/<gid>/meetings.json")]
 pub fn meetings_json(conn: ObservDbConn, _l: MentorGuard, gid: i32) -> Json<Vec<Meeting>> {

--- a/src/groups/handlers.rs
+++ b/src/groups/handlers.rs
@@ -142,12 +142,17 @@ pub fn individual_meetings(conn: ObservDbConn, l: MentorGuard, gid: i32, mid: i3
         .first(&*conn)
         .expect("Failed to get meetings from database");
 
-    Some(MeetingTemplate {
-        logged_in: Some(l.0),
-        users: meeting_users(&*conn, &m),
-        group: g,
-        meeting: m,
-    })
+    if m.group_id != gid {
+        return None
+    }
+    else {
+        Some(MeetingTemplate {
+            logged_in: Some(l.0),
+            users: meeting_users(&*conn, &m),
+            group: g,
+            meeting: m,
+        })
+    }
 }
 
 /// GET handler for `/groups/<gid>/meetings.json`

--- a/src/groups/mod.rs
+++ b/src/groups/mod.rs
@@ -14,6 +14,7 @@
 //! - `/groups/<gid>/meetings
 //! - `/groups/<gid>/meetings.json
 //! - `/groups/<gid>/meetings/new
+//! - '/groups/<gid>/meetings/<mid>
 
 pub mod handlers;
 pub mod models;

--- a/src/groups/models.rs
+++ b/src/groups/models.rs
@@ -77,7 +77,7 @@ impl Attendable for Meeting {
         false
     }
     fn url(&self) -> String {
-        format!("/h/{}", self.group_id)
+        format!("/groups/{}/meetings/{}", self.group_id, self.id)
     }
 }
 

--- a/src/groups/templates.rs
+++ b/src/groups/templates.rs
@@ -80,3 +80,21 @@ pub struct AddUserTemplate {
     pub group: Group,
     pub all_users: Vec<User>,
 }
+
+/// Add Meeting page template
+///
+/// HTML file: `group/meeting.html`
+///
+/// The page that shows the attedance code and attendees for a meeting
+#[derive(Template)]
+#[template(path = "group/meeting.html")]
+pub struct MeetingTemplate {
+    /// Login information for the group
+    pub logged_in: OptUser,
+    /// Group that contains this meeting
+    pub group: Group,
+    /// Users this template is for
+    pub users: Vec<User>,
+    /// Meeting that uses this template
+    pub meeting: Meeting
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -175,6 +175,7 @@ pub fn rocket(test_config: Option<rocket::Config>) -> rocket::Rocket {
                 group_user_delete,
                 group_delete,
                 meetings,
+                individual_meetings,
                 meetings_json,
                 meeting_new_post,
                 group_edit,

--- a/templates/grade-summary.html
+++ b/templates/grade-summary.html
@@ -10,7 +10,7 @@
     <summary>Show all Attendance</summary>
     <ul>
         {% for at in summary.attendances %}
-        <li><a href="{{ at.url() }}">{{ at.name() }} {{ at.time() }}</a></li>
+        <li><a href="{{ at.url() }}">{{ at.name() }} </a></li>
         {% endfor %}
     </ul>
 </details>

--- a/templates/group/group.html
+++ b/templates/group/group.html
@@ -61,11 +61,11 @@ Room: {{ val }}
     {% match logged_in %}
     {% when Some with (u) %}
     <li>
-        Meeting at {{ meeting.happened_at }}
+        <a href="/groups/{{ group.id }}/meetings/{{ meeting.id }}">Meeting</a> at {{ meeting.happened_at }}
         {% if u.tier > 0 %}
             code:
             <code>{{ meeting.code }}</code>
-            <a href="/big?text={{ meeting.code }}">View</a>
+            <a href="/big?text={{ meeting.code }}">View Code</a>
         {% endif %}
     </li>
     {% when None %}

--- a/templates/group/meeting.html
+++ b/templates/group/meeting.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}{{ group.name }} Meeting at {{ meeting.happened_at }} {% endblock %}
+{% block title %}{{ group.name }} Meeting on {{ meeting.happened_at }} {% endblock %}
 
 {% block head %}
 <style>
@@ -14,11 +14,8 @@
 Room: {{ val }}
 {% when None %}
 {% endmatch %}
-
-<h2>Code</h2>
-<code>
-    {{ meeting.code }}
-</code>
+<br>
+Code: <code> {{ meeting.code }} </code>
 
 <h2>Attendees</h2>
 <ul>

--- a/templates/group/meeting.html
+++ b/templates/group/meeting.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+
+{% block title %}{{ group.name }} Meeting at {% endblock %}
+
+{% block head %}
+<style>
+</style>
+{% endblock %}
+
+{% block content %}
+
+{% match group.location %}
+{% when Some with (val) %}
+Room: {{ val }}
+{% when None %}
+{% endmatch %}
+
+<h2>Attendees</h2>
+<ul>
+    {% for user in users %}
+    <li>
+        <a href="/users/{{ user.id }}">{{ user.real_name }} ({{ user.handle }})</a>
+    </li>
+    {% endfor %}
+</ul>
+
+{% endblock %}

--- a/templates/group/meeting.html
+++ b/templates/group/meeting.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}{{ group.name }} Meeting at {% endblock %}
+{% block title %}{{ group.name }} Meeting at {{ meeting.happened_at }} {% endblock %}
 
 {% block head %}
 <style>
@@ -14,6 +14,11 @@
 Room: {{ val }}
 {% when None %}
 {% endmatch %}
+
+<h2>Code</h2>
+<code>
+    {{ meeting.code }}
+</code>
 
 <h2>Attendees</h2>
 <ul>


### PR DESCRIPTION
**Related Issues**
#37 

**Describe the Changes**
I've added a meeting page that shows the people who have attended a certain meeting. This solves the above issue, and mentors/administrators can now view certain details about a particular meeting all on one page.

**Still To Do**
We could maybe implement a way of uploading slides to the meeting page, but that's up to @rushsteve1 . At the moment, the webpage seems to have enough information on it.

**Problems**
This may or may not work retroactively in that students who have attended a meeting before this code was implemented might not show up on meeting pages. This needs to be tested.

**Acknowledgements**
@rushsteve1 for general assistance.
