### PR TITLE
Unit Testing for Groups

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::auth::crypto::*;
 use crate::models::*;
 use diesel::insert_into;
+use diesel::delete;
 use diesel::prelude::*;
 use rocket::config::{Config, Environment, LoggingLevel, Value};
 use rocket::http::Status;
@@ -135,8 +136,12 @@ fn check_static_content() {
     cleanup(String::from("test_static_content"));
 }
 
+// Tests the addition, editing, and deletion of a user
 #[test]
 fn add_user() {
+
+    // cleanup(String::from("test_add_user"));
+
     let config = setup(String::from("test_add_user"));
 
     let _client = Client::new(rocket(config)).unwrap();
@@ -186,6 +191,62 @@ fn add_user() {
     }
 
     assert_eq!("JD1".to_string(), user.handle);
-
+   // User update: create new instance with updated values and enter into db
+   // or edit values directly somehow?
+     
+ 
+    // User deletion
+    delete(users.filter(&email.eq(&*nu.email)))
+        .execute(&conn)
+        .expect("Failed to delete user from database");
+   
     cleanup(String::from("test_add_user"));
 }
+
+
+
+  
+// Tests the addition, editing, and deletion of a group 
+#[test]
+fn add_group() {
+    let config = setup(String::from("test_add_group"));
+
+    let _client = Client::new(rocket(config)).unwrap();
+    let conn_url = create_connection_url(&_client);
+
+    let conn = SqliteConnection::establish(conn_url.as_str())
+        .expect("Failed to connect to database in AddGroupTest");
+    embedded_migrations::run(&conn).expect("Failed to run embedded migrations");
+    use crate::schema::groups::dsl::*;
+    let nu = NewGroup {
+        name: String::from("Test Group"),
+        owner_id: 0,
+        location: Some(String::from("DCC 318")),
+    };
+    insert_into(groups)
+        .values(&nu)
+        .execute(&conn)
+        .expect("Failed to add group to database");
+
+    let group: Group = groups
+        //.filter(&email.eq(&*nu.email))
+        .first(&conn)
+        .expect("Failed to get group from database");
+    {
+        use crate::schema::relation_group_user::dsl::*;
+        insert_into(relation_group_user)
+            .values(&NewRelationGroupUser {
+                group_id: group.id,
+                user_id: 1,
+            })
+            .execute(&conn)
+            .expect("Failed to insert new relation into database");
+    }
+    // Update to group name and meeting location  
+    
+    // Group deletion
+    delete(groups.filter(id.eq(1)))
+        .execute(&conn)
+        .expect("Failed to delete group from database");
+    cleanup(String::from("test_add_group"));
+} 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,8 +1,8 @@
 use super::*;
 use crate::auth::crypto::*;
 use crate::models::*;
-use diesel::insert_into;
 use diesel::delete;
+use diesel::insert_into;
 use diesel::prelude::*;
 use rocket::config::{Config, Environment, LoggingLevel, Value};
 use rocket::http::Status;
@@ -139,9 +139,6 @@ fn check_static_content() {
 // Tests the addition, editing, and deletion of a user
 #[test]
 fn add_user() {
-
-    // cleanup(String::from("test_add_user"));
-
     let config = setup(String::from("test_add_user"));
 
     let _client = Client::new(rocket(config)).unwrap();
@@ -188,25 +185,26 @@ fn add_user() {
             })
             .execute(&conn)
             .expect("Failed to insert new relation into database");
+
+        // Relation deletion
+        delete(relation_group_user.filter(user_id.eq(user.id)))
+            .execute(&conn)
+            .expect("Failed to insert new relation into database");
     }
 
     assert_eq!("JD1".to_string(), user.handle);
-   // User update: create new instance with updated values and enter into db
-   // or edit values directly somehow?
-     
- 
+    // User update: create new instance with updated values and enter into db
+    // or edit values directly somehow?
+
     // User deletion
-    delete(users.filter(&email.eq(&*nu.email)))
+    delete(users.find(user.id))
         .execute(&conn)
         .expect("Failed to delete user from database");
-   
+
     cleanup(String::from("test_add_user"));
 }
 
-
-
-  
-// Tests the addition, editing, and deletion of a group 
+// Tests the addition, editing, and deletion of a group
 #[test]
 fn add_group() {
     let config = setup(String::from("test_add_group"));
@@ -229,7 +227,6 @@ fn add_group() {
         .expect("Failed to add group to database");
 
     let group: Group = groups
-        //.filter(&email.eq(&*nu.email))
         .first(&conn)
         .expect("Failed to get group from database");
     {
@@ -237,16 +234,23 @@ fn add_group() {
         insert_into(relation_group_user)
             .values(&NewRelationGroupUser {
                 group_id: group.id,
-                user_id: 1,
+                user_id: 0,
             })
             .execute(&conn)
             .expect("Failed to insert new relation into database");
+
+        // Relation deletion
+        delete(relation_group_user.filter(group_id.eq(group.id)))
+            .execute(&conn)
+            .expect("Failed to insert new relation into database");
     }
-    // Update to group name and meeting location  
-    
+    // Update to group name and meeting location
+
     // Group deletion
-    delete(groups.filter(id.eq(1)))
+    delete(groups.find(group.id))
         .execute(&conn)
         .expect("Failed to delete group from database");
+
+    // Cleanup database
     cleanup(String::from("test_add_group"));
-} 
+}


### PR DESCRIPTION
**Related Issues**
This pull request is regarding Issue #19 regarding Automated Testing.

**Describe the Changes**
I made an add_group test in the same vein as the existing add_user test, and also added deletion tests for both add_user and add_group.

**Still To Do**
Editing a user and group are good short term additions. Long term, many more tests can be made, especially regarding attendance and meetings.

**Problems**
The delete tests currently fail, which hopefully have a simple fix.

**Acknowledgements**
@BrianMejia for making the original testing format and giving lots of helpful advice.
