### PR TITLE
iCalendar support for the calendar

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ reqwest = "^0.9.16"
 rocket = "^0.4.1"
 rss = "^1.7.0"
 rust-embed = "^5.1.0"
+icalendar = "^0.7.1"
 
 # By using * we match the library versions
 regex = "*"

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,6 +124,7 @@ pub fn rocket(test_config: Option<rocket::Config>) -> rocket::Rocket {
                 // Calendar
                 calendar,
                 calendar_json,
+                calendar_ics,
                 event,
                 event_edit,
                 event_edit_put,

--- a/src/news/handlers.rs
+++ b/src/news/handlers.rs
@@ -1,11 +1,10 @@
-use std::io::Cursor;
-
 use diesel::prelude::*;
 use diesel::{delete, insert_into, update};
-use rocket::http::{ContentType, Status};
 use rocket::request::Form;
-use rocket::response::{Redirect, Response};
+use rocket::response::Redirect;
 
+use rocket::http::ContentType;
+use rocket::response::Content;
 use rocket_contrib::json::Json;
 
 use crate::guards::*;
@@ -38,7 +37,7 @@ pub fn news_json(conn: ObservDbConn, _l: MaybeLoggedIn) -> Json<Vec<NewsStory>> 
 }
 
 #[get("/news.xml")]
-pub fn news_rss(conn: ObservDbConn) -> Response<'static> {
+pub fn news_rss(conn: ObservDbConn) -> Content<String> {
     use crate::schema::news::dsl::*;
     use rss;
 
@@ -73,11 +72,8 @@ pub fn news_rss(conn: ObservDbConn) -> Response<'static> {
         .expect("Failed to build RSS Channel")
         .to_string();
 
-    Response::build()
-        .status(Status::Ok)
-        .header(ContentType::XML)
-        .sized_body(Cursor::new(xml))
-        .finalize()
+    // RSS feeds have their own special mimetype
+    Content(ContentType::new("application", "rss+xml"), xml)
 }
 
 #[get("/news/<nid>")]

--- a/src/news/models.rs
+++ b/src/news/models.rs
@@ -26,7 +26,9 @@ pub struct NewNewsStory {
 use crate::calendar::models::smart_time_parse;
 impl NewNewsStory {
     pub fn fix_times(&mut self) -> Option<()> {
-        self.happened_at = smart_time_parse(&self.happened_at)?.format("%F %R").to_string();
+        self.happened_at = smart_time_parse(&self.happened_at)?
+            .format("%F %R")
+            .to_string();
         Some(())
     }
 }

--- a/src/projects/handlers.rs
+++ b/src/projects/handlers.rs
@@ -171,7 +171,7 @@ pub fn project_new_post(
             return Redirect::to(format!("/projects/new?e={}", FormError::TakenName))
         }
         Err(_) => return Redirect::to(format!("/projects/new?e={}", FormError::Other)),
-        Ok(_) => ()
+        Ok(_) => (),
     }
 
     // retrieves the object from the database after creating it

--- a/static/js/calendar.js
+++ b/static/js/calendar.js
@@ -1,54 +1,52 @@
 const sharedOpts = {
-    plugins: ['dayGrid', 'list'],
-    themeSystem: 'bootstrap',
+  plugins: ["dayGrid", "list"],
+  themeSystem: "bootstrap"
 };
 
-document.addEventListener('DOMContentLoaded', function () {
-    var calendarEl = document.getElementById('calendar');
+document.addEventListener("DOMContentLoaded", function() {
+  var calendarEl = document.getElementById("calendar");
 
-    if (calendarEl) {
-        var calendar = new FullCalendar.Calendar(calendarEl, {
-            ...sharedOpts,
-            header: {
-                right: 'dayGridMonth,listWeek today prev,next'
-            },
-            defaultView: 'dayGridMonth',
-            events: {
-                url: "/calendar.json",
-                editable: false
-            },
-            eventDataTransform: (data) => ({
-                ...data,
-                url: "/calendar/" + data.id
-            })
+  if (calendarEl) {
+    var calendar = new FullCalendar.Calendar(calendarEl, {
+      ...sharedOpts,
+      header: {
+        right: "dayGridMonth,listYear today prev,next"
+      },
+      defaultView: "dayGridMonth",
+      events: {
+        url: "/calendar.json",
+        editable: false
+      },
+      eventDataTransform: data => ({
+        ...data,
+        url: "/calendar/" + data.id
+      })
+    });
 
-        });
+    calendar.render();
+  }
 
-        calendar.render();
-    }
+  var newsEl = document.getElementById("news");
 
-    var newsEl = document.getElementById('news');
+  if (newsEl) {
+    var news = new FullCalendar.Calendar(newsEl, {
+      ...sharedOpts,
+      header: {
+        right: "listYear,dayGridMonth today prev,next"
+      },
+      defaultView: "list",
+      events: {
+        url: "/news.json",
+        editable: false
+      },
+      eventDataTransform: data => ({
+        ...data,
+        start: data.happened_at,
+        end: data.happend_at,
+        url: "/news/" + data.id
+      })
+    });
 
-    if (newsEl) {
-        var news = new FullCalendar.Calendar(newsEl, {
-            ...sharedOpts,
-            header: {
-                right: 'listWeek,dayGridMonth today prev,next'
-            },
-            defaultView: 'list',
-            events: {
-                url: "/news.json",
-                editable: false
-            },
-            eventDataTransform: (data) => ({
-                ...data,
-                start: data.happened_at,
-                end: data.happend_at,
-                url: "/news/" + data.id
-            })
-
-        });
-
-        news.render();
-    }
+    news.render();
+  }
 });

--- a/templates/calendar/calendar.html
+++ b/templates/calendar/calendar.html
@@ -25,6 +25,9 @@
     {% when None %}
     {% endmatch %}
 </div>
+<div class="btn-group mr-2">
+    <a class="btn btn-outline-secondary" href="/calendar.ics">iCal</a>
+</div>
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
**Related Issues**
#18 

**Describe the Changes**
The calendar now supports automatically generating an iCalendar file which can be subscribed to using a variety of services like Google Calendar.

This required the `icalendar` crate and the creation of a new `/calendar.ics` route to serve it.

Also made some fixes to the `calendar.js` file, notably fixing formatting and line-endings.

**Still To Do**
I learned about they `Content` type for Rocket responses, so I might use that in a few more places quickly.

**Problems**
None technical that I know of.
However like the RSS button on the News page, it may be good to add a tooltip explaining what this is actually for.